### PR TITLE
fix: openssl usage example to produce exactly 32 characters

### DIFF
--- a/docs/middleware/encryptcookie.md
+++ b/docs/middleware/encryptcookie.md
@@ -58,7 +58,7 @@ app.Post("/", func(c fiber.Ctx) error {
 
 :::note
 The `Key` parameter requires an encoded string of 16, 24, or 32 bytes for encryption, corresponding to AES-128, AES-192, and AES-256-GCM standards, respectively. Ensure the key is randomly generated and securely stored.
-To generate a 32 char key, use `openssl rand -base64 32` or `encryptcookie.GenerateKey(32)`. Avoid dynamically generating a new `Key` with `encryptcookie.GenerateKey(32)` at each application startup to prevent rendering previously encrypted data inaccessible.
+To generate a 32 char key, use `openssl rand -base64 24 | cut -c1-32` or `encryptcookie.GenerateKey(32)`. Avoid dynamically generating a new `Key` with `encryptcookie.GenerateKey(32)` at each application startup to prevent rendering previously encrypted data inaccessible.
 :::
 
 ## Config


### PR DESCRIPTION
# Description

THis is pure documentation fix. Default example for `openssl` command line (at crypto-cookie doc) producing more than 32 character line.  Base64 encoding expands the output size by approximately 33% so needed adjustments are down number of random bytes requested to 24 and cutting result to exact 32 chars.